### PR TITLE
スポット一覧ページ

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -12,6 +12,7 @@
   ],
   "rules": {
     "react/react-in-jsx-scope": "off",
+    "@typescript-eslint/no-explicit-any": "off",
     "import/order": [2, { "alphabetize": { "order": "asc" } }],
     "import/no-unresolved": "off",
     "prettier/prettier": [

--- a/front/app/spots/[id]/page.tsx
+++ b/front/app/spots/[id]/page.tsx
@@ -1,6 +1,14 @@
-"use client";
+'use client'
 
-import Image from "next/image";
+import {
+  Favorite,
+  LocationOn,
+  AccessTime,
+  Phone,
+  Share,
+  Star,
+  Person,
+} from '@mui/icons-material'
 import {
   Box,
   Container,
@@ -17,68 +25,60 @@ import {
   ListItemText,
   Divider,
   Avatar,
-} from "@mui/material";
-import {
-  Favorite,
-  LocationOn,
-  AccessTime,
-  Phone,
-  Share,
-  Star,
-  Person,
-} from "@mui/icons-material";
-import GoogleMapsIframe from "@/components/layout/google-maps-iframe";
-import { mockSpotLocations } from "@/lib/google-maps";
+} from '@mui/material'
+import Image from 'next/image'
+import GoogleMapsIframe from '@/components/layout/google-maps-iframe'
+import { mockSpotLocations } from '@/lib/google-maps'
 
 // モックデータ（実際の実装では[id]パラメータを使用）
 const spotData = {
   id: 1,
-  name: "隠れ茶屋 竹の庵",
-  category: "グルメ",
+  name: '隠れ茶屋 竹の庵',
+  category: 'グルメ',
   description:
-    "竹林の奥にある秘密の茶屋。地元の人だけが知る絶品の抹茶スイーツが楽しめます。築80年の古民家を改装した店内は、静寂に包まれた特別な空間。季節ごとに変わる和菓子と、丁寧に点てられた抹茶の組み合わせは格別です。店主の心のこもったおもてなしと、時間を忘れさせてくれる雰囲気が多くの人に愛され続けています。",
+    '竹林の奥にある秘密の茶屋。地元の人だけが知る絶品の抹茶スイーツが楽しめます。築80年の古民家を改装した店内は、静寂に包まれた特別な空間。季節ごとに変わる和菓子と、丁寧に点てられた抹茶の組み合わせは格別です。店主の心のこもったおもてなしと、時間を忘れさせてくれる雰囲気が多くの人に愛され続けています。',
   images: [
-    "/placeholder.svg?height=400&width=600",
-    "/placeholder.svg?height=300&width=400",
-    "/placeholder.svg?height=300&width=400",
-    "/placeholder.svg?height=300&width=400",
+    '/placeholder.svg?height=400&width=600',
+    '/placeholder.svg?height=300&width=400',
+    '/placeholder.svg?height=300&width=400',
+    '/placeholder.svg?height=300&width=400',
   ],
   likes: 24,
   rating: 4.8,
   reviews: 12,
-  address: "神奈川県鎌倉市山ノ内123-45",
-  phone: "0467-12-3456",
-  hours: "10:00-17:00（火曜定休）",
-  access: "北鎌倉駅から徒歩15分、竹林の小道を奥へ進んだ先",
-  tags: ["隠れ家", "抹茶", "古民家", "静寂", "和菓子"],
-  price: "¥1,000-2,000",
-  website: "https://example.com",
+  address: '神奈川県鎌倉市山ノ内123-45',
+  phone: '0467-12-3456',
+  hours: '10:00-17:00（火曜定休）',
+  access: '北鎌倉駅から徒歩15分、竹林の小道を奥へ進んだ先',
+  tags: ['隠れ家', '抹茶', '古民家', '静寂', '和菓子'],
+  price: '¥1,000-2,000',
+  website: 'https://example.com',
   location: {
     lat: 35.3367,
     lng: 139.5468,
   },
-};
+}
 
 const mockReviews = [
   {
     id: 1,
-    user: "山田花子",
-    avatar: "/placeholder.svg?height=40&width=40",
+    user: '山田花子',
+    avatar: '/placeholder.svg?height=40&width=40',
     rating: 5,
-    date: "2024-01-15",
+    date: '2024-01-15',
     comment:
-      "本当に隠れた名店でした！抹茶の味が深くて、和菓子との相性も抜群。静かな環境でゆっくりできます。",
+      '本当に隠れた名店でした！抹茶の味が深くて、和菓子との相性も抜群。静かな環境でゆっくりできます。',
   },
   {
     id: 2,
-    user: "佐藤太郎",
-    avatar: "/placeholder.svg?height=40&width=40",
+    user: '佐藤太郎',
+    avatar: '/placeholder.svg?height=40&width=40',
     rating: 4,
-    date: "2024-01-10",
+    date: '2024-01-10',
     comment:
-      "竹林を抜けた先にある素敵なお店。少し分かりにくい場所ですが、それがまた特別感を演出しています。",
+      '竹林を抜けた先にある素敵なお店。少し分かりにくい場所ですが、それがまた特別感を演出しています。',
   },
-];
+]
 
 export default function SpotDetailPage() {
   return (
@@ -92,7 +92,7 @@ export default function SpotDetailPage() {
               <Grid item xs={12} md={8}>
                 <Card className="relative h-64 md:h-80 overflow-hidden">
                   <Image
-                    src={spotData.images[0] || "/placeholder.svg"}
+                    src={spotData.images[0] || '/placeholder.svg'}
                     alt={spotData.name}
                     fill
                     className="object-cover"
@@ -107,7 +107,7 @@ export default function SpotDetailPage() {
                     <Grid item xs={4} md={12} key={index}>
                       <Card className="relative h-20 md:h-24 overflow-hidden">
                         <Image
-                          src={image || "/placeholder.svg"}
+                          src={image || '/placeholder.svg'}
                           alt={`${spotData.name} ${index + 2}`}
                           fill
                           className="object-cover"
@@ -335,7 +335,7 @@ export default function SpotDetailPage() {
                           variant="body2"
                           className="text-primary-500 hover:underline cursor-pointer"
                           onClick={() =>
-                            window.open(spotData.website, "_blank")
+                            window.open(spotData.website, '_blank')
                           }
                         >
                           公式サイトを見る
@@ -382,7 +382,7 @@ export default function SpotDetailPage() {
                     >
                       <Card className="w-16 h-16 overflow-hidden flex-shrink-0">
                         <Image
-                          src={spot.image || "/placeholder.svg"}
+                          src={spot.image || '/placeholder.svg'}
                           alt={spot.name}
                           width={64}
                           height={64}
@@ -412,5 +412,5 @@ export default function SpotDetailPage() {
         </Grid>
       </Grid>
     </Container>
-  );
+  )
 }

--- a/front/app/spots/[id]/page.tsx
+++ b/front/app/spots/[id]/page.tsx
@@ -12,7 +12,6 @@ import {
 import {
   Box,
   Container,
-  Grid,
   Card,
   CardContent,
   Typography,
@@ -26,6 +25,7 @@ import {
   Divider,
   Avatar,
 } from '@mui/material'
+import Grid from '@mui/material/Grid'
 import Image from 'next/image'
 import GoogleMapsIframe from '@/components/layout/google-maps-iframe'
 import { mockSpotLocations } from '@/lib/google-maps'
@@ -85,11 +85,11 @@ export default function SpotDetailPage() {
     <Container maxWidth="lg" className="py-8">
       <Grid container spacing={4}>
         {/* メイン情報 */}
-        <Grid item xs={12} lg={8}>
+        <Grid size={{ xs: 12, lg: 8 }}>
           <Box className="space-y-6">
             {/* 画像ギャラリー */}
             <Grid container spacing={2}>
-              <Grid item xs={12} md={8}>
+              <Grid size={{ xs: 12, lg: 8 }}>
                 <Card className="relative h-64 md:h-80 overflow-hidden">
                   <Image
                     src={spotData.images[0] || '/placeholder.svg'}
@@ -101,10 +101,10 @@ export default function SpotDetailPage() {
                   />
                 </Card>
               </Grid>
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, lg: 8 }}>
                 <Grid container spacing={1}>
                   {spotData.images.slice(1, 4).map((image, index) => (
-                    <Grid item xs={4} md={12} key={index}>
+                    <Grid size={{ xs: 12, lg: 8 }} key={index}>
                       <Card className="relative h-20 md:h-24 overflow-hidden">
                         <Image
                           src={image || '/placeholder.svg'}
@@ -257,7 +257,7 @@ export default function SpotDetailPage() {
         </Grid>
 
         {/* サイドバー */}
-        <Grid item xs={12} lg={4}>
+        <Grid size={{ xs: 12, lg: 4 }}>
           <Box className="space-y-6">
             {/* 基本情報 */}
             <Card>

--- a/front/app/spots/[id]/page.tsx
+++ b/front/app/spots/[id]/page.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import Image from "next/image";
+import {
+  Box,
+  Container,
+  Grid,
+  Card,
+  CardContent,
+  Typography,
+  Button,
+  Chip,
+  Rating,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Divider,
+  Avatar,
+} from "@mui/material";
+import {
+  Favorite,
+  LocationOn,
+  AccessTime,
+  Phone,
+  Share,
+  Star,
+  Person,
+} from "@mui/icons-material";
+import GoogleMapsIframe from "@/components/layout/google-maps-iframe";
+import { mockSpotLocations } from "@/lib/google-maps";
+
+// モックデータ（実際の実装では[id]パラメータを使用）
+const spotData = {
+  id: 1,
+  name: "隠れ茶屋 竹の庵",
+  category: "グルメ",
+  description:
+    "竹林の奥にある秘密の茶屋。地元の人だけが知る絶品の抹茶スイーツが楽しめます。築80年の古民家を改装した店内は、静寂に包まれた特別な空間。季節ごとに変わる和菓子と、丁寧に点てられた抹茶の組み合わせは格別です。店主の心のこもったおもてなしと、時間を忘れさせてくれる雰囲気が多くの人に愛され続けています。",
+  images: [
+    "/placeholder.svg?height=400&width=600",
+    "/placeholder.svg?height=300&width=400",
+    "/placeholder.svg?height=300&width=400",
+    "/placeholder.svg?height=300&width=400",
+  ],
+  likes: 24,
+  rating: 4.8,
+  reviews: 12,
+  address: "神奈川県鎌倉市山ノ内123-45",
+  phone: "0467-12-3456",
+  hours: "10:00-17:00（火曜定休）",
+  access: "北鎌倉駅から徒歩15分、竹林の小道を奥へ進んだ先",
+  tags: ["隠れ家", "抹茶", "古民家", "静寂", "和菓子"],
+  price: "¥1,000-2,000",
+  website: "https://example.com",
+  location: {
+    lat: 35.3367,
+    lng: 139.5468,
+  },
+};
+
+const mockReviews = [
+  {
+    id: 1,
+    user: "山田花子",
+    avatar: "/placeholder.svg?height=40&width=40",
+    rating: 5,
+    date: "2024-01-15",
+    comment:
+      "本当に隠れた名店でした！抹茶の味が深くて、和菓子との相性も抜群。静かな環境でゆっくりできます。",
+  },
+  {
+    id: 2,
+    user: "佐藤太郎",
+    avatar: "/placeholder.svg?height=40&width=40",
+    rating: 4,
+    date: "2024-01-10",
+    comment:
+      "竹林を抜けた先にある素敵なお店。少し分かりにくい場所ですが、それがまた特別感を演出しています。",
+  },
+];
+
+export default function SpotDetailPage() {
+  return (
+    <Container maxWidth="lg" className="py-8">
+      <Grid container spacing={4}>
+        {/* メイン情報 */}
+        <Grid item xs={12} lg={8}>
+          <Box className="space-y-6">
+            {/* 画像ギャラリー */}
+            <Grid container spacing={2}>
+              <Grid item xs={12} md={8}>
+                <Card className="relative h-64 md:h-80 overflow-hidden">
+                  <Image
+                    src={spotData.images[0] || "/placeholder.svg"}
+                    alt={spotData.name}
+                    fill
+                    className="object-cover"
+                    priority
+                    sizes="(max-width: 768px) 100vw, 66vw"
+                  />
+                </Card>
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <Grid container spacing={1}>
+                  {spotData.images.slice(1, 4).map((image, index) => (
+                    <Grid item xs={4} md={12} key={index}>
+                      <Card className="relative h-20 md:h-24 overflow-hidden">
+                        <Image
+                          src={image || "/placeholder.svg"}
+                          alt={`${spotData.name} ${index + 2}`}
+                          fill
+                          className="object-cover"
+                          sizes="(max-width: 768px) 33vw, 25vw"
+                        />
+                      </Card>
+                    </Grid>
+                  ))}
+                </Grid>
+              </Grid>
+            </Grid>
+
+            {/* スポット情報 */}
+            <Card>
+              <CardContent className="p-6">
+                <Box className="flex justify-between items-start mb-4">
+                  <Box>
+                    <Typography variant="h4" className="font-bold mb-2">
+                      {spotData.name}
+                    </Typography>
+                    <Box className="flex items-center gap-4 mb-2">
+                      <Box className="flex items-center gap-1">
+                        <Rating
+                          value={spotData.rating}
+                          precision={0.1}
+                          size="small"
+                          readOnly
+                        />
+                        <Typography variant="body2" color="text.secondary">
+                          {spotData.rating} ({spotData.reviews}件のレビュー)
+                        </Typography>
+                      </Box>
+                      <Chip label={spotData.category} color="secondary" />
+                    </Box>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      className="mb-2"
+                    >
+                      価格帯: {spotData.price}
+                    </Typography>
+                  </Box>
+                  <Button
+                    variant="outlined"
+                    startIcon={<Favorite />}
+                    className="flex-shrink-0"
+                  >
+                    {spotData.likes}
+                  </Button>
+                </Box>
+
+                <Typography className="text-gray-700 leading-relaxed mb-4 text-lg">
+                  {spotData.description}
+                </Typography>
+
+                <Box className="flex flex-wrap gap-2">
+                  {spotData.tags.map((tag) => (
+                    <Chip
+                      key={tag}
+                      label={`#${tag}`}
+                      size="small"
+                      variant="outlined"
+                    />
+                  ))}
+                </Box>
+              </CardContent>
+            </Card>
+
+            {/* Google Maps iframe */}
+            <Card>
+              <CardContent className="p-6">
+                <Typography
+                  variant="h6"
+                  className="flex items-center gap-2 mb-4"
+                >
+                  <LocationOn />
+                  アクセス・地図
+                </Typography>
+                <GoogleMapsIframe
+                  location={spotData.location}
+                  spotName={spotData.name}
+                  address={spotData.address}
+                  height="350px"
+                  zoom={16}
+                  showOpenButton={true}
+                />
+                <Box className="mt-4 p-4 bg-gray-50 rounded-lg">
+                  <Typography variant="body1" className="font-medium mb-2">
+                    アクセス方法
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    className="leading-relaxed"
+                  >
+                    {spotData.access}
+                  </Typography>
+                </Box>
+              </CardContent>
+            </Card>
+
+            {/* レビューセクション */}
+            <Card>
+              <CardContent className="p-6">
+                <Typography variant="h6" className="mb-4">
+                  レビュー ({mockReviews.length}件)
+                </Typography>
+                <Box className="space-y-4">
+                  {mockReviews.map((review) => (
+                    <Box key={review.id}>
+                      <Box className="flex items-start gap-3">
+                        <Avatar
+                          src={review.avatar}
+                          alt={review.user}
+                          className="w-10 h-10"
+                        >
+                          <Person />
+                        </Avatar>
+                        <Box className="flex-1">
+                          <Box className="flex items-center gap-2 mb-1">
+                            <Typography variant="body1" className="font-medium">
+                              {review.user}
+                            </Typography>
+                            <Rating
+                              value={review.rating}
+                              size="small"
+                              readOnly
+                            />
+                            <Typography variant="body2" color="text.secondary">
+                              {review.date}
+                            </Typography>
+                          </Box>
+                          <Typography variant="body2" color="text.secondary">
+                            {review.comment}
+                          </Typography>
+                        </Box>
+                      </Box>
+                      {review.id !== mockReviews[mockReviews.length - 1].id && (
+                        <Divider className="mt-4" />
+                      )}
+                    </Box>
+                  ))}
+                </Box>
+              </CardContent>
+            </Card>
+          </Box>
+        </Grid>
+
+        {/* サイドバー */}
+        <Grid item xs={12} lg={4}>
+          <Box className="space-y-6">
+            {/* 基本情報 */}
+            <Card>
+              <CardContent className="p-6">
+                <Typography variant="h6" className="mb-4">
+                  基本情報
+                </Typography>
+                <List disablePadding>
+                  <ListItem disablePadding className="mb-3">
+                    <ListItemIcon className="min-w-0 mr-3">
+                      <LocationOn className="text-gray-400" />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={
+                        <Typography variant="body2" className="font-medium">
+                          住所
+                        </Typography>
+                      }
+                      secondary={
+                        <Typography variant="body2" color="text.secondary">
+                          {spotData.address}
+                        </Typography>
+                      }
+                    />
+                  </ListItem>
+
+                  <ListItem disablePadding className="mb-3">
+                    <ListItemIcon className="min-w-0 mr-3">
+                      <Phone className="text-gray-400" />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={
+                        <Typography variant="body2" className="font-medium">
+                          電話番号
+                        </Typography>
+                      }
+                      secondary={
+                        <Typography variant="body2" color="text.secondary">
+                          {spotData.phone}
+                        </Typography>
+                      }
+                    />
+                  </ListItem>
+
+                  <ListItem disablePadding className="mb-3">
+                    <ListItemIcon className="min-w-0 mr-3">
+                      <AccessTime className="text-gray-400" />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={
+                        <Typography variant="body2" className="font-medium">
+                          営業時間
+                        </Typography>
+                      }
+                      secondary={
+                        <Typography variant="body2" color="text.secondary">
+                          {spotData.hours}
+                        </Typography>
+                      }
+                    />
+                  </ListItem>
+
+                  <ListItem disablePadding>
+                    <ListItemIcon className="min-w-0 mr-3">
+                      <Share className="text-gray-400" />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={
+                        <Typography variant="body2" className="font-medium">
+                          ウェブサイト
+                        </Typography>
+                      }
+                      secondary={
+                        <Typography
+                          variant="body2"
+                          className="text-primary-500 hover:underline cursor-pointer"
+                          onClick={() =>
+                            window.open(spotData.website, "_blank")
+                          }
+                        >
+                          公式サイトを見る
+                        </Typography>
+                      }
+                    />
+                  </ListItem>
+                </List>
+              </CardContent>
+            </Card>
+
+            {/* アクション */}
+            <Card>
+              <CardContent className="p-6 space-y-3">
+                <Button
+                  variant="contained"
+                  fullWidth
+                  startIcon={<Favorite />}
+                  color="secondary"
+                  className="bg-accent-500 text-accent-foreground hover:bg-accent-600"
+                >
+                  いいねする
+                </Button>
+                <Button variant="outlined" fullWidth startIcon={<Share />}>
+                  共有する
+                </Button>
+                <Button variant="outlined" fullWidth startIcon={<Star />}>
+                  レビューを書く
+                </Button>
+              </CardContent>
+            </Card>
+
+            {/* 近くのスポット */}
+            <Card>
+              <CardContent className="p-6">
+                <Typography variant="h6" className="mb-4">
+                  近くのスポット
+                </Typography>
+                <Box className="space-y-3">
+                  {mockSpotLocations.slice(1, 3).map((spot) => (
+                    <Box
+                      key={spot.id}
+                      className="flex gap-3 p-3 rounded-lg hover:bg-gray-50 cursor-pointer"
+                    >
+                      <Card className="w-16 h-16 overflow-hidden flex-shrink-0">
+                        <Image
+                          src={spot.image || "/placeholder.svg"}
+                          alt={spot.name}
+                          width={64}
+                          height={64}
+                          className="object-cover"
+                        />
+                      </Card>
+                      <Box className="flex-1">
+                        <Typography variant="body2" className="font-medium">
+                          {spot.name}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          徒歩8分
+                        </Typography>
+                        <Chip
+                          label={spot.category}
+                          size="small"
+                          variant="outlined"
+                          className="ml-2"
+                        />
+                      </Box>
+                    </Box>
+                  ))}
+                </Box>
+              </CardContent>
+            </Card>
+          </Box>
+        </Grid>
+      </Grid>
+    </Container>
+  );
+}

--- a/front/app/spots/page.tsx
+++ b/front/app/spots/page.tsx
@@ -11,7 +11,6 @@ import {
 import {
   Box,
   Container,
-  Grid,
   Card,
   CardContent,
   CardMedia,
@@ -25,6 +24,7 @@ import {
   Fab,
   Drawer,
 } from '@mui/material'
+import Grid from '@mui/material/Grid'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useState } from 'react'
@@ -83,7 +83,7 @@ export default function SpotsPage() {
       {/* 検索バー */}
       <Box className="mb-8">
         <Grid container spacing={2} className="mb-4">
-          <Grid item xs={12} md={10}>
+          <Grid size={{ xs: 12, md: 10 }}>
             <TextField
               fullWidth
               placeholder="スポット名やキーワードで検索..."
@@ -99,7 +99,7 @@ export default function SpotsPage() {
               className="bg-white"
             />
           </Grid>
-          <Grid item xs={12} md={2}>
+          <Grid size={{ xs: 12, md: 2 }}>
             <Button
               variant="outlined"
               fullWidth
@@ -151,7 +151,7 @@ export default function SpotsPage() {
       {/* 検索結果 */}
       <Grid container spacing={3}>
         {spotsWithDistance.map((spot) => (
-          <Grid item xs={12} md={6} lg={4} key={spot.id}>
+          <Grid size={{ xs: 12, md: 6, lg: 4 }} key={spot.id}>
             <Card
               className={`h-full hover:shadow-xl transition-all duration-300 hover:-translate-y-1 cursor-pointer ${
                 selectedSpot?.id === spot.id ? 'ring-2 ring-primary-500' : ''

--- a/front/app/spots/page.tsx
+++ b/front/app/spots/page.tsx
@@ -1,8 +1,13 @@
-"use client";
+'use client'
 
-import { useState } from "react";
-import Image from "next/image";
-import Link from "next/link";
+import {
+  Search,
+  LocationOn,
+  Favorite,
+  FilterList,
+  Map,
+  Close,
+} from '@mui/icons-material'
 import {
   Box,
   Container,
@@ -19,42 +24,37 @@ import {
   IconButton,
   Fab,
   Drawer,
-} from "@mui/material";
-import {
-  Search,
-  LocationOn,
-  Favorite,
-  FilterList,
-  Map,
-  Close,
-} from "@mui/icons-material";
-import InteractiveMap from "@/components/layout/interactive-map";
+} from '@mui/material'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useState } from 'react'
+import InteractiveMap from '@/components/layout/interactive-map'
 import {
   mockSpotLocations,
   calculateDistance,
   formatDistance,
   KAMAKURA_CENTER,
   type SpotLocation,
-} from "@/lib/google-maps";
+} from '@/lib/google-maps'
 
 export default function SpotsPage() {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState("全て");
-  const [selectedSpot, setSelectedSpot] = useState<SpotLocation | null>(null);
-  const [showMap, setShowMap] = useState(false);
-  const [userLocation, setUserLocation] = useState(KAMAKURA_CENTER);
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedCategory, setSelectedCategory] = useState('全て')
+  const [selectedSpot, setSelectedSpot] = useState<SpotLocation | null>(null)
+  const [showMap, setShowMap] = useState(false)
+  const [userLocation] = useState(KAMAKURA_CENTER)
 
-  const categories = ["全て", "グルメ", "景観", "文化", "歴史", "自然"];
+  const categories = ['全て', 'グルメ', '景観', '文化', '歴史', '自然']
 
   // フィルタリングされたスポット
   const filteredSpots = mockSpotLocations.filter((spot) => {
     const matchesSearch =
       spot.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      spot.description.toLowerCase().includes(searchQuery.toLowerCase());
+      spot.description.toLowerCase().includes(searchQuery.toLowerCase())
     const matchesCategory =
-      selectedCategory === "全て" || spot.category === selectedCategory;
-    return matchesSearch && matchesCategory;
-  });
+      selectedCategory === '全て' || spot.category === selectedCategory
+    return matchesSearch && matchesCategory
+  })
 
   // 距離を計算してソート
   const spotsWithDistance = filteredSpots
@@ -62,11 +62,11 @@ export default function SpotsPage() {
       ...spot,
       distance: calculateDistance(userLocation, spot),
     }))
-    .sort((a, b) => a.distance - b.distance);
+    .sort((a, b) => a.distance - b.distance)
 
   const handleSpotSelect = (spot: SpotLocation) => {
-    setSelectedSpot(spot);
-  };
+    setSelectedSpot(spot)
+  }
 
   return (
     <Container maxWidth="lg" className="py-8">
@@ -117,8 +117,8 @@ export default function SpotsPage() {
             <Chip
               key={category}
               label={category}
-              variant={selectedCategory === category ? "filled" : "outlined"}
-              color={selectedCategory === category ? "primary" : "default"}
+              variant={selectedCategory === category ? 'filled' : 'outlined'}
+              color={selectedCategory === category ? 'primary' : 'default'}
               onClick={() => setSelectedCategory(category)}
               className="cursor-pointer whitespace-nowrap"
             />
@@ -154,14 +154,14 @@ export default function SpotsPage() {
           <Grid item xs={12} md={6} lg={4} key={spot.id}>
             <Card
               className={`h-full hover:shadow-xl transition-all duration-300 hover:-translate-y-1 cursor-pointer ${
-                selectedSpot?.id === spot.id ? "ring-2 ring-primary-500" : ""
+                selectedSpot?.id === spot.id ? 'ring-2 ring-primary-500' : ''
               }`}
               onClick={() => handleSpotSelect(spot)}
             >
               <Box className="relative">
                 <CardMedia component="div" className="h-48 relative">
                   <Image
-                    src={spot.image || "/placeholder.svg"}
+                    src={spot.image || '/placeholder.svg'}
                     alt={spot.name}
                     fill
                     className="object-cover"
@@ -215,11 +215,11 @@ export default function SpotsPage() {
                   <Button
                     size="small"
                     onClick={(e) => {
-                      e.stopPropagation();
-                      handleSpotSelect(spot);
+                      e.stopPropagation()
+                      handleSpotSelect(spot)
                     }}
                     variant={
-                      selectedSpot?.id === spot.id ? "contained" : "outlined"
+                      selectedSpot?.id === spot.id ? 'contained' : 'outlined'
                     }
                   >
                     地図で表示
@@ -252,9 +252,9 @@ export default function SpotsPage() {
           <Button
             variant="outlined"
             onClick={() => {
-              setSearchQuery("");
-              setSelectedCategory("全て");
-              setSelectedSpot(null);
+              setSearchQuery('')
+              setSelectedCategory('全て')
+              setSelectedSpot(null)
             }}
           >
             検索条件をリセット
@@ -277,7 +277,7 @@ export default function SpotsPage() {
         open={showMap}
         onClose={() => setShowMap(false)}
         PaperProps={{
-          sx: { height: "80vh" },
+          sx: { height: '80vh' },
         }}
       >
         <Box className="p-4 h-full flex flex-col">
@@ -298,5 +298,5 @@ export default function SpotsPage() {
         </Box>
       </Drawer>
     </Container>
-  );
+  )
 }

--- a/front/app/spots/page.tsx
+++ b/front/app/spots/page.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import {
+  Box,
+  Container,
+  Grid,
+  Card,
+  CardContent,
+  CardMedia,
+  Typography,
+  TextField,
+  InputAdornment,
+  Button,
+  Chip,
+  Rating,
+  IconButton,
+  Fab,
+  Drawer,
+} from "@mui/material";
+import {
+  Search,
+  LocationOn,
+  Favorite,
+  FilterList,
+  Map,
+  Close,
+} from "@mui/icons-material";
+import InteractiveMap from "@/components/layout/interactive-map";
+import {
+  mockSpotLocations,
+  calculateDistance,
+  formatDistance,
+  KAMAKURA_CENTER,
+  type SpotLocation,
+} from "@/lib/google-maps";
+
+export default function SpotsPage() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState("全て");
+  const [selectedSpot, setSelectedSpot] = useState<SpotLocation | null>(null);
+  const [showMap, setShowMap] = useState(false);
+  const [userLocation, setUserLocation] = useState(KAMAKURA_CENTER);
+
+  const categories = ["全て", "グルメ", "景観", "文化", "歴史", "自然"];
+
+  // フィルタリングされたスポット
+  const filteredSpots = mockSpotLocations.filter((spot) => {
+    const matchesSearch =
+      spot.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      spot.description.toLowerCase().includes(searchQuery.toLowerCase());
+    const matchesCategory =
+      selectedCategory === "全て" || spot.category === selectedCategory;
+    return matchesSearch && matchesCategory;
+  });
+
+  // 距離を計算してソート
+  const spotsWithDistance = filteredSpots
+    .map((spot) => ({
+      ...spot,
+      distance: calculateDistance(userLocation, spot),
+    }))
+    .sort((a, b) => a.distance - b.distance);
+
+  const handleSpotSelect = (spot: SpotLocation) => {
+    setSelectedSpot(spot);
+  };
+
+  return (
+    <Container maxWidth="lg" className="py-8">
+      {/* インタラクティブマップ */}
+      <Box className="mb-8">
+        <InteractiveMap
+          selectedSpot={selectedSpot}
+          onSpotSelect={handleSpotSelect}
+          height="400px"
+          showControls={true}
+        />
+      </Box>
+
+      {/* 検索バー */}
+      <Box className="mb-8">
+        <Grid container spacing={2} className="mb-4">
+          <Grid item xs={12} md={10}>
+            <TextField
+              fullWidth
+              placeholder="スポット名やキーワードで検索..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Search className="text-gray-400" />
+                  </InputAdornment>
+                ),
+              }}
+              className="bg-white"
+            />
+          </Grid>
+          <Grid item xs={12} md={2}>
+            <Button
+              variant="outlined"
+              fullWidth
+              startIcon={<FilterList />}
+              className="h-full border-primary-300 text-primary-600 hover:bg-primary-50"
+            >
+              フィルター
+            </Button>
+          </Grid>
+        </Grid>
+
+        {/* カテゴリータブ */}
+        <Box className="flex gap-2 overflow-x-auto pb-2">
+          {categories.map((category) => (
+            <Chip
+              key={category}
+              label={category}
+              variant={selectedCategory === category ? "filled" : "outlined"}
+              color={selectedCategory === category ? "primary" : "default"}
+              onClick={() => setSelectedCategory(category)}
+              className="cursor-pointer whitespace-nowrap"
+            />
+          ))}
+        </Box>
+      </Box>
+
+      {/* 検索結果ヘッダー */}
+      <Box className="mb-6">
+        <Typography
+          variant="h5"
+          className="font-semibold text-primary-500 mb-2"
+        >
+          検索結果
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          {spotsWithDistance.length}件のスポットが見つかりました
+          {selectedSpot && (
+            <Chip
+              label={`選択中: ${selectedSpot.name}`}
+              onDelete={() => setSelectedSpot(null)}
+              className="ml-2"
+              color="primary"
+              variant="outlined"
+            />
+          )}
+        </Typography>
+      </Box>
+
+      {/* 検索結果 */}
+      <Grid container spacing={3}>
+        {spotsWithDistance.map((spot) => (
+          <Grid item xs={12} md={6} lg={4} key={spot.id}>
+            <Card
+              className={`h-full hover:shadow-xl transition-all duration-300 hover:-translate-y-1 cursor-pointer ${
+                selectedSpot?.id === spot.id ? "ring-2 ring-primary-500" : ""
+              }`}
+              onClick={() => handleSpotSelect(spot)}
+            >
+              <Box className="relative">
+                <CardMedia component="div" className="h-48 relative">
+                  <Image
+                    src={spot.image || "/placeholder.svg"}
+                    alt={spot.name}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                  />
+                </CardMedia>
+                <IconButton className="absolute top-2 right-2 bg-white/90 hover:bg-white shadow-md">
+                  <Favorite className="text-gray-400" />
+                </IconButton>
+                <Chip
+                  label={spot.category}
+                  size="small"
+                  className="absolute top-2 left-2 bg-white/90 font-medium"
+                />
+              </Box>
+              <CardContent className="p-4">
+                <Typography
+                  variant="h6"
+                  className="font-semibold mb-2 line-clamp-1"
+                >
+                  {spot.name}
+                </Typography>
+                <Box className="flex items-center gap-2 mb-2">
+                  <Rating
+                    value={spot.rating}
+                    precision={0.1}
+                    size="small"
+                    readOnly
+                  />
+                  <Typography variant="body2" color="text.secondary">
+                    {spot.rating}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    •
+                  </Typography>
+                  <Box className="flex items-center gap-1">
+                    <LocationOn className="text-gray-400" fontSize="small" />
+                    <Typography variant="body2" color="text.secondary">
+                      {formatDistance(spot.distance)}
+                    </Typography>
+                  </Box>
+                </Box>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  className="mb-4 line-clamp-2"
+                >
+                  {spot.description}
+                </Typography>
+                <Box className="flex justify-between items-center">
+                  <Button
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleSpotSelect(spot);
+                    }}
+                    variant={
+                      selectedSpot?.id === spot.id ? "contained" : "outlined"
+                    }
+                  >
+                    地図で表示
+                  </Button>
+                  <Button
+                    size="small"
+                    component={Link}
+                    href={`/spots/${spot.id}`}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    詳細を見る
+                  </Button>
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+
+      {/* 結果が見つからない場合 */}
+      {spotsWithDistance.length === 0 && (
+        <Box className="text-center py-16">
+          <Search className="text-6xl text-gray-300 mb-4" />
+          <Typography variant="h6" className="font-semibold text-gray-600 mb-2">
+            検索結果が見つかりませんでした
+          </Typography>
+          <Typography color="text.secondary" className="mb-6">
+            検索条件を変更して再度お試しください
+          </Typography>
+          <Button
+            variant="outlined"
+            onClick={() => {
+              setSearchQuery("");
+              setSelectedCategory("全て");
+              setSelectedSpot(null);
+            }}
+          >
+            検索条件をリセット
+          </Button>
+        </Box>
+      )}
+
+      {/* モバイル用地図表示ボタン */}
+      <Fab
+        color="primary"
+        className="fixed bottom-6 right-6 bg-primary-500 hover:bg-primary-600 md:hidden"
+        onClick={() => setShowMap(true)}
+      >
+        <Map />
+      </Fab>
+
+      {/* モバイル用地図ドロワー */}
+      <Drawer
+        anchor="bottom"
+        open={showMap}
+        onClose={() => setShowMap(false)}
+        PaperProps={{
+          sx: { height: "80vh" },
+        }}
+      >
+        <Box className="p-4 h-full flex flex-col">
+          <Box className="flex justify-between items-center mb-4">
+            <Typography variant="h6">地図</Typography>
+            <IconButton onClick={() => setShowMap(false)}>
+              <Close />
+            </IconButton>
+          </Box>
+          <Box className="flex-1">
+            <InteractiveMap
+              selectedSpot={selectedSpot}
+              onSpotSelect={handleSpotSelect}
+              height="100%"
+              showControls={true}
+            />
+          </Box>
+        </Box>
+      </Drawer>
+    </Container>
+  );
+}

--- a/front/components/layout/google-maps-iframe.tsx
+++ b/front/components/layout/google-maps-iframe.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Box, Card, Typography, Button, Alert } from "@mui/material";
+import { LocationOn, OpenInNew } from "@mui/icons-material";
+import {
+  generateGoogleMapsEmbedUrl,
+  generateGoogleMapsSearchUrl,
+  type MapLocation,
+} from "@/lib/google-maps";
+
+interface GoogleMapsIframeProps {
+  location: MapLocation;
+  spotName?: string;
+  address?: string;
+  height?: string;
+  zoom?: number;
+  showOpenButton?: boolean;
+}
+
+export default function GoogleMapsIframe({
+  location,
+  spotName,
+  address,
+  height = "300px",
+  zoom = 16,
+  showOpenButton = true,
+}: GoogleMapsIframeProps) {
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+
+  // APIキーが設定されていない場合の表示
+  if (!apiKey) {
+    return (
+      <Card className="p-6">
+        <Alert severity="warning" className="mb-4">
+          Google Maps APIキーが設定されていません
+        </Alert>
+        <Box className="bg-secondary-50 h-64 flex items-center justify-center">
+          <Box className="text-center text-gray-600">
+            <LocationOn className="text-6xl mb-2" />
+            <Typography variant="h6">地図を表示するには</Typography>
+            <Typography variant="body2">
+              Google Maps APIキーの設定が必要です
+            </Typography>
+          </Box>
+        </Box>
+      </Card>
+    );
+  }
+
+  // 埋め込みURLを生成（スポット名がある場合は検索、ない場合は座標表示）
+  const embedUrl = spotName
+    ? generateGoogleMapsSearchUrl(spotName, location)
+    : generateGoogleMapsEmbedUrl(location, zoom);
+
+  // Google Mapsで開くURL
+  const openInMapsUrl = `https://www.google.com/maps/search/?api=1&query=${location.lat},${location.lng}`;
+
+  return (
+    <Card className="overflow-hidden">
+      <Box className="relative">
+        <iframe
+          src={embedUrl}
+          width="100%"
+          height={height}
+          style={{ border: 0 }}
+          allowFullScreen
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          title={spotName ? `${spotName}の地図` : "地図"}
+        />
+
+        {/* Google Mapsで開くボタン */}
+        {showOpenButton && (
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<OpenInNew />}
+            className="absolute top-2 right-2 bg-white text-primary-500 hover:bg-gray-50 shadow-md"
+            onClick={() => window.open(openInMapsUrl, "_blank")}
+            sx={{
+              minWidth: "auto",
+              padding: "4px 8px",
+              fontSize: "12px",
+            }}
+          >
+            開く
+          </Button>
+        )}
+      </Box>
+
+      {/* 住所表示 */}
+      {address && (
+        <Box className="p-3 bg-gray-50 border-t">
+          <Box className="flex items-start gap-2">
+            <LocationOn className="text-gray-400 mt-0.5" fontSize="small" />
+            <Box>
+              <Typography variant="body2" className="font-medium">
+                住所
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {address}
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+      )}
+    </Card>
+  );
+}

--- a/front/components/layout/google-maps-iframe.tsx
+++ b/front/components/layout/google-maps-iframe.tsx
@@ -1,31 +1,31 @@
-"use client";
+'use client'
 
-import { Box, Card, Typography, Button, Alert } from "@mui/material";
-import { LocationOn, OpenInNew } from "@mui/icons-material";
+import { LocationOn, OpenInNew } from '@mui/icons-material'
+import { Box, Card, Typography, Button, Alert } from '@mui/material'
 import {
   generateGoogleMapsEmbedUrl,
   generateGoogleMapsSearchUrl,
   type MapLocation,
-} from "@/lib/google-maps";
+} from '@/lib/google-maps'
 
 interface GoogleMapsIframeProps {
-  location: MapLocation;
-  spotName?: string;
-  address?: string;
-  height?: string;
-  zoom?: number;
-  showOpenButton?: boolean;
+  location: MapLocation
+  spotName?: string
+  address?: string
+  height?: string
+  zoom?: number
+  showOpenButton?: boolean
 }
 
 export default function GoogleMapsIframe({
   location,
   spotName,
   address,
-  height = "300px",
+  height = '300px',
   zoom = 16,
   showOpenButton = true,
 }: GoogleMapsIframeProps) {
-  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
 
   // APIキーが設定されていない場合の表示
   if (!apiKey) {
@@ -44,16 +44,16 @@ export default function GoogleMapsIframe({
           </Box>
         </Box>
       </Card>
-    );
+    )
   }
 
   // 埋め込みURLを生成（スポット名がある場合は検索、ない場合は座標表示）
   const embedUrl = spotName
     ? generateGoogleMapsSearchUrl(spotName, location)
-    : generateGoogleMapsEmbedUrl(location, zoom);
+    : generateGoogleMapsEmbedUrl(location, zoom)
 
   // Google Mapsで開くURL
-  const openInMapsUrl = `https://www.google.com/maps/search/?api=1&query=${location.lat},${location.lng}`;
+  const openInMapsUrl = `https://www.google.com/maps/search/?api=1&query=${location.lat},${location.lng}`
 
   return (
     <Card className="overflow-hidden">
@@ -66,7 +66,7 @@ export default function GoogleMapsIframe({
           allowFullScreen
           loading="lazy"
           referrerPolicy="no-referrer-when-downgrade"
-          title={spotName ? `${spotName}の地図` : "地図"}
+          title={spotName ? `${spotName}の地図` : '地図'}
         />
 
         {/* Google Mapsで開くボタン */}
@@ -76,11 +76,11 @@ export default function GoogleMapsIframe({
             size="small"
             startIcon={<OpenInNew />}
             className="absolute top-2 right-2 bg-white text-primary-500 hover:bg-gray-50 shadow-md"
-            onClick={() => window.open(openInMapsUrl, "_blank")}
+            onClick={() => window.open(openInMapsUrl, '_blank')}
             sx={{
-              minWidth: "auto",
-              padding: "4px 8px",
-              fontSize: "12px",
+              minWidth: 'auto',
+              padding: '4px 8px',
+              fontSize: '12px',
             }}
           >
             開く
@@ -105,5 +105,5 @@ export default function GoogleMapsIframe({
         </Box>
       )}
     </Card>
-  );
+  )
 }

--- a/front/components/layout/interactive-map.tsx
+++ b/front/components/layout/interactive-map.tsx
@@ -20,7 +20,7 @@ interface InteractiveMapProps {
 declare global {
   interface Window {
     google: typeof google
-    initMap: () => void
+    initMap?: () => void
   }
 }
 

--- a/front/components/layout/interactive-map.tsx
+++ b/front/components/layout/interactive-map.tsx
@@ -33,7 +33,7 @@ export default function InteractiveMap({
   const mapRef = useRef<HTMLDivElement>(null)
   const [map, setMap] = useState<any>(null)
   const [markers, setMarkers] = useState<any[]>([])
-  const [setUserLocation] = useState<MapLocation | null>(null)
+  const [userLocation, setUserLocation] = useState<MapLocation | null>(null);
   const [mapType, setMapType] = useState<'roadmap' | 'satellite'>('roadmap')
   const [isLoading, setIsLoading] = useState(true)
 

--- a/front/components/layout/interactive-map.tsx
+++ b/front/components/layout/interactive-map.tsx
@@ -20,7 +20,7 @@ interface InteractiveMapProps {
 declare global {
   interface Window {
     google: any
-    initMap: () => void
+    initMap?: () => void
   }
 }
 

--- a/front/components/layout/interactive-map.tsx
+++ b/front/components/layout/interactive-map.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Box, Card, Typography, Chip, Fab } from "@mui/material";
+import { LocationOn, MyLocation, Layers } from "@mui/icons-material";
+import {
+  mockSpotLocations,
+  KAMAKURA_CENTER,
+  type SpotLocation,
+  type MapLocation,
+} from "@/lib/google-maps";
+
+interface InteractiveMapProps {
+  selectedSpot?: SpotLocation | null;
+  onSpotSelect?: (spot: SpotLocation) => void;
+  height?: string;
+  showControls?: boolean;
+}
+
+declare global {
+  interface Window {
+    google: any;
+    initMap: () => void;
+  }
+}
+
+export default function InteractiveMap({
+  selectedSpot,
+  onSpotSelect,
+  height = "400px",
+  showControls = true,
+}: InteractiveMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const [map, setMap] = useState<any>(null);
+  const [markers, setMarkers] = useState<any[]>([]);
+  const [userLocation, setUserLocation] = useState<MapLocation | null>(null);
+  const [mapType, setMapType] = useState<"roadmap" | "satellite">("roadmap");
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Google Maps APIの初期化
+  useEffect(() => {
+    const initializeMap = () => {
+      if (!mapRef.current || !window.google) return;
+
+      const mapInstance = new window.google.maps.Map(mapRef.current, {
+        center: KAMAKURA_CENTER,
+        zoom: 13,
+        mapTypeId: mapType,
+        styles: [
+          {
+            featureType: "poi",
+            elementType: "labels",
+            stylers: [{ visibility: "off" }],
+          },
+        ],
+        mapTypeControl: false,
+        streetViewControl: false,
+        fullscreenControl: false,
+      });
+
+      setMap(mapInstance);
+      setIsLoading(false);
+
+      // マーカーを追加
+      const newMarkers = mockSpotLocations.map((spot) => {
+        const marker = new window.google.maps.Marker({
+          position: { lat: spot.lat, lng: spot.lng },
+          map: mapInstance,
+          title: spot.name,
+          icon: {
+            url: getCategoryIcon(spot.category),
+            scaledSize: new window.google.maps.Size(40, 40),
+          },
+        });
+
+        // 情報ウィンドウ
+        const infoWindow = new window.google.maps.InfoWindow({
+          content: createInfoWindowContent(spot),
+        });
+
+        marker.addListener("click", () => {
+          // 他の情報ウィンドウを閉じる
+          markers.forEach((m) => m.infoWindow?.close());
+          infoWindow.open(mapInstance, marker);
+          onSpotSelect?.(spot);
+        });
+
+        return { marker, infoWindow, spot };
+      });
+
+      setMarkers(newMarkers);
+    };
+
+    // Google Maps APIが読み込まれているかチェック
+    if (window.google && window.google.maps) {
+      initializeMap();
+    } else {
+      // Google Maps APIを動的に読み込み
+      const script = document.createElement("script");
+      script.src = `https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places&callback=initMap`;
+      script.async = true;
+      script.defer = true;
+
+      window.initMap = initializeMap;
+      document.head.appendChild(script);
+
+      return () => {
+        document.head.removeChild(script);
+        delete window.initMap;
+      };
+    }
+  }, [mapType, onSpotSelect]);
+
+  // 選択されたスポットにフォーカス
+  useEffect(() => {
+    if (map && selectedSpot) {
+      map.setCenter({ lat: selectedSpot.lat, lng: selectedSpot.lng });
+      map.setZoom(16);
+
+      // 対応するマーカーの情報ウィンドウを開く
+      const targetMarker = markers.find((m) => m.spot.id === selectedSpot.id);
+      if (targetMarker) {
+        markers.forEach((m) => m.infoWindow?.close());
+        targetMarker.infoWindow.open(map, targetMarker.marker);
+      }
+    }
+  }, [selectedSpot, map, markers]);
+
+  // 現在地を取得
+  const getCurrentLocation = () => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const location = {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+          };
+          setUserLocation(location);
+
+          if (map) {
+            map.setCenter(location);
+            map.setZoom(15);
+
+            // 現在地マーカーを追加
+            new window.google.maps.Marker({
+              position: location,
+              map: map,
+              title: "現在地",
+              icon: {
+                url:
+                  "data:image/svg+xml;charset=UTF-8," +
+                  encodeURIComponent(`
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="12" cy="12" r="8" fill="#4285F4" stroke="#ffffff" strokeWidth="2"/>
+                    <circle cx="12" cy="12" r="3" fill="#ffffff"/>
+                  </svg>
+                `),
+                scaledSize: new window.google.maps.Size(24, 24),
+              },
+            });
+          }
+        },
+        (error) => {
+          console.error("位置情報の取得に失敗しました:", error);
+        }
+      );
+    }
+  };
+
+  // カテゴリー別アイコンを取得
+  const getCategoryIcon = (category: string): string => {
+    const iconMap: { [key: string]: string } = {
+      グルメ: "#FF6B6B",
+      景観: "#4ECDC4",
+      文化: "#45B7D1",
+      歴史: "#96CEB4",
+      自然: "#FFEAA7",
+    };
+
+    const color = iconMap[category] || "#DDA0DD";
+    return (
+      "data:image/svg+xml;charset=UTF-8," +
+      encodeURIComponent(`
+        <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="20" r="18" fill="${color}" stroke="#ffffff" strokeWidth="2"/>
+          <circle cx="20" cy="20" r="8" fill="#ffffff"/>
+        </svg>
+      `)
+    );
+  };
+
+  // 情報ウィンドウのコンテンツを作成
+  const createInfoWindowContent = (spot: SpotLocation): string => {
+    return `
+      <div style="padding: 8px; max-width: 200px;">
+        <h3 style="margin: 0 0 8px 0; font-size: 16px; font-weight: bold;">${spot.name}</h3>
+        <p style="margin: 0 0 8px 0; font-size: 12px; color: #666;">${spot.category}</p>
+        <p style="margin: 0 0 8px 0; font-size: 14px; line-height: 1.4;">${spot.description}</p>
+        <div style="display: flex; align-items: center; gap: 4px;">
+          <span style="color: #FFD700;">★</span>
+          <span style="font-size: 14px; font-weight: bold;">${spot.rating}</span>
+        </div>
+      </div>
+    `;
+  };
+
+  return (
+    <Card className="relative overflow-hidden">
+      <Box
+        ref={mapRef}
+        sx={{
+          height: height,
+          width: "100%",
+          position: "relative",
+        }}
+      />
+
+      {/* ローディング表示 */}
+      {isLoading && (
+        <Box
+          className="absolute inset-0 flex items-center justify-center bg-secondary-50"
+          sx={{ zIndex: 1 }}
+        >
+          <Box className="text-center">
+            <LocationOn className="text-6xl text-primary-500 mb-2" />
+            <Typography variant="h6">地図を読み込み中...</Typography>
+          </Box>
+        </Box>
+      )}
+
+      {/* コントロールボタン */}
+      {showControls && !isLoading && (
+        <>
+          {/* 現在地ボタン */}
+          <Fab
+            size="small"
+            className="absolute top-4 right-4 bg-white hover:bg-gray-50 shadow-md"
+            onClick={getCurrentLocation}
+            sx={{ zIndex: 2 }}
+          >
+            <MyLocation className="text-primary-500" />
+          </Fab>
+
+          {/* 地図タイプ切り替えボタン */}
+          <Fab
+            size="small"
+            className="absolute top-16 right-4 bg-white hover:bg-gray-50 shadow-md"
+            onClick={() =>
+              setMapType(mapType === "roadmap" ? "satellite" : "roadmap")
+            }
+            sx={{ zIndex: 2 }}
+          >
+            <Layers className="text-primary-500" />
+          </Fab>
+
+          {/* 凡例 */}
+          <Card className="absolute bottom-4 left-4 p-2" sx={{ zIndex: 2 }}>
+            <Typography variant="caption" className="font-semibold mb-2 block">
+              カテゴリー
+            </Typography>
+            <Box className="flex flex-wrap gap-1">
+              {["グルメ", "景観", "文化", "歴史", "自然"].map((category) => (
+                <Chip
+                  key={category}
+                  label={category}
+                  size="small"
+                  variant="outlined"
+                />
+              ))}
+            </Box>
+          </Card>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/front/components/layout/interactive-map.tsx
+++ b/front/components/layout/interactive-map.tsx
@@ -33,7 +33,7 @@ export default function InteractiveMap({
   const mapRef = useRef<HTMLDivElement>(null)
   const [map, setMap] = useState<any>(null)
   const [markers, setMarkers] = useState<any[]>([])
-  const [userLocation, setUserLocation] = useState<MapLocation | null>(null);
+  const [, setUserLocation] = useState<MapLocation | null>(null)
   const [mapType, setMapType] = useState<'roadmap' | 'satellite'>('roadmap')
   const [isLoading, setIsLoading] = useState(true)
 

--- a/front/components/layout/interactive-map.tsx
+++ b/front/components/layout/interactive-map.tsx
@@ -1,46 +1,46 @@
-"use client";
+'use client'
 
-import { LocationOn, MyLocation, Layers } from "@mui/icons-material";
-import { Box, Card, Typography, Chip, Fab } from "@mui/material";
-import { useEffect, useRef, useState } from "react";
+import { LocationOn, MyLocation, Layers } from '@mui/icons-material'
+import { Box, Card, Typography, Chip, Fab } from '@mui/material'
+import { useEffect, useRef, useState } from 'react'
 import {
   mockSpotLocations,
   KAMAKURA_CENTER,
   type SpotLocation,
   type MapLocation,
-} from "@/lib/google-maps";
+} from '@/lib/google-maps'
 
 interface InteractiveMapProps {
-  selectedSpot?: SpotLocation | null;
-  onSpotSelect?: (spot: SpotLocation) => void;
-  height?: string;
-  showControls?: boolean;
+  selectedSpot?: SpotLocation | null
+  onSpotSelect?: (spot: SpotLocation) => void
+  height?: string
+  showControls?: boolean
 }
 
 declare global {
   interface Window {
     google: any
-    initMap: () => void;
+    initMap: () => void
   }
 }
 
 export default function InteractiveMap({
   selectedSpot,
   onSpotSelect,
-  height = "400px",
+  height = '400px',
   showControls = true,
 }: InteractiveMapProps) {
-  const mapRef = useRef<HTMLDivElement>(null);
-  const [map, setMap] = useState<any>(null);
-  const [markers, setMarkers] = useState<any[]>([]);
-  const [setUserLocation] = useState<MapLocation | null>(null);
-  const [mapType, setMapType] = useState<"roadmap" | "satellite">("roadmap");
-  const [isLoading, setIsLoading] = useState(true);
+  const mapRef = useRef<HTMLDivElement>(null)
+  const [map, setMap] = useState<any>(null)
+  const [markers, setMarkers] = useState<any[]>([])
+  const [setUserLocation] = useState<MapLocation | null>(null)
+  const [mapType, setMapType] = useState<'roadmap' | 'satellite'>('roadmap')
+  const [isLoading, setIsLoading] = useState(true)
 
   // Google Maps APIの初期化
   useEffect(() => {
     const initializeMap = () => {
-      if (!mapRef.current || !window.google) return;
+      if (!mapRef.current || !window.google) return
 
       const mapInstance = new window.google.maps.Map(mapRef.current, {
         center: KAMAKURA_CENTER,
@@ -48,18 +48,18 @@ export default function InteractiveMap({
         mapTypeId: mapType,
         styles: [
           {
-            featureType: "poi",
-            elementType: "labels",
-            stylers: [{ visibility: "off" }],
+            featureType: 'poi',
+            elementType: 'labels',
+            stylers: [{ visibility: 'off' }],
           },
         ],
         mapTypeControl: false,
         streetViewControl: false,
         fullscreenControl: false,
-      });
+      })
 
-      setMap(mapInstance);
-      setIsLoading(false);
+      setMap(mapInstance)
+      setIsLoading(false)
 
       // マーカーを追加
       const newMarkers = mockSpotLocations.map((spot) => {
@@ -71,60 +71,60 @@ export default function InteractiveMap({
             url: getCategoryIcon(spot.category),
             scaledSize: new window.google.maps.Size(40, 40),
           },
-        });
+        })
 
         // 情報ウィンドウ
         const infoWindow = new window.google.maps.InfoWindow({
           content: createInfoWindowContent(spot),
-        });
+        })
 
-        marker.addListener("click", () => {
+        marker.addListener('click', () => {
           // 他の情報ウィンドウを閉じる
-          markers.forEach((m) => m.infoWindow?.close());
-          infoWindow.open(mapInstance, marker);
-          onSpotSelect?.(spot);
-        });
+          markers.forEach((m) => m.infoWindow?.close())
+          infoWindow.open(mapInstance, marker)
+          onSpotSelect?.(spot)
+        })
 
-        return { marker, infoWindow, spot };
-      });
+        return { marker, infoWindow, spot }
+      })
 
-      setMarkers(newMarkers);
-    };
+      setMarkers(newMarkers)
+    }
 
     // Google Maps APIが読み込まれているかチェック
     if (window.google && window.google.maps) {
-      initializeMap();
+      initializeMap()
     } else {
       // Google Maps APIを動的に読み込み
-      const script = document.createElement("script");
-      script.src = `https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places&callback=initMap`;
-      script.async = true;
-      script.defer = true;
+      const script = document.createElement('script')
+      script.src = `https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places&callback=initMap`
+      script.async = true
+      script.defer = true
 
-      window.initMap = initializeMap;
-      document.head.appendChild(script);
+      window.initMap = initializeMap
+      document.head.appendChild(script)
 
       return () => {
-        document.head.removeChild(script);
-        delete window.initMap;
-      };
+        document.head.removeChild(script)
+        delete window.initMap
+      }
     }
-  }, [mapType, onSpotSelect]);
+  }, [mapType, onSpotSelect])
 
   // 選択されたスポットにフォーカス
   useEffect(() => {
     if (map && selectedSpot) {
-      map.setCenter({ lat: selectedSpot.lat, lng: selectedSpot.lng });
-      map.setZoom(16);
+      map.setCenter({ lat: selectedSpot.lat, lng: selectedSpot.lng })
+      map.setZoom(16)
 
       // 対応するマーカーの情報ウィンドウを開く
-      const targetMarker = markers.find((m) => m.spot.id === selectedSpot.id);
+      const targetMarker = markers.find((m) => m.spot.id === selectedSpot.id)
       if (targetMarker) {
-        markers.forEach((m) => m.infoWindow?.close());
-        targetMarker.infoWindow.open(map, targetMarker.marker);
+        markers.forEach((m) => m.infoWindow?.close())
+        targetMarker.infoWindow.open(map, targetMarker.marker)
       }
     }
-  }, [selectedSpot, map, markers]);
+  }, [selectedSpot, map, markers])
 
   // 現在地を取得
   const getCurrentLocation = () => {
@@ -134,21 +134,21 @@ export default function InteractiveMap({
           const location = {
             lat: position.coords.latitude,
             lng: position.coords.longitude,
-          };
-          setUserLocation(location);
+          }
+          setUserLocation(location)
 
           if (map) {
-            map.setCenter(location);
-            map.setZoom(15);
+            map.setCenter(location)
+            map.setZoom(15)
 
             // 現在地マーカーを追加
             new window.google.maps.Marker({
               position: location,
               map: map,
-              title: "現在地",
+              title: '現在地',
               icon: {
                 url:
-                  "data:image/svg+xml;charset=UTF-8," +
+                  'data:image/svg+xml;charset=UTF-8,' +
                   encodeURIComponent(`
                   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <circle cx="12" cy="12" r="8" fill="#4285F4" stroke="#ffffff" strokeWidth="2"/>
@@ -157,37 +157,37 @@ export default function InteractiveMap({
                 `),
                 scaledSize: new window.google.maps.Size(24, 24),
               },
-            });
+            })
           }
         },
         (error) => {
-          console.error("位置情報の取得に失敗しました:", error);
-        }
-      );
+          console.error('位置情報の取得に失敗しました:', error)
+        },
+      )
     }
-  };
+  }
 
   // カテゴリー別アイコンを取得
   const getCategoryIcon = (category: string): string => {
     const iconMap: { [key: string]: string } = {
-      グルメ: "#FF6B6B",
-      景観: "#4ECDC4",
-      文化: "#45B7D1",
-      歴史: "#96CEB4",
-      自然: "#FFEAA7",
-    };
+      グルメ: '#FF6B6B',
+      景観: '#4ECDC4',
+      文化: '#45B7D1',
+      歴史: '#96CEB4',
+      自然: '#FFEAA7',
+    }
 
-    const color = iconMap[category] || "#DDA0DD";
+    const color = iconMap[category] || '#DDA0DD'
     return (
-      "data:image/svg+xml;charset=UTF-8," +
+      'data:image/svg+xml;charset=UTF-8,' +
       encodeURIComponent(`
         <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
           <circle cx="20" cy="20" r="18" fill="${color}" stroke="#ffffff" strokeWidth="2"/>
           <circle cx="20" cy="20" r="8" fill="#ffffff"/>
         </svg>
       `)
-    );
-  };
+    )
+  }
 
   // 情報ウィンドウのコンテンツを作成
   const createInfoWindowContent = (spot: SpotLocation): string => {
@@ -201,8 +201,8 @@ export default function InteractiveMap({
           <span style="font-size: 14px; font-weight: bold;">${spot.rating}</span>
         </div>
       </div>
-    `;
-  };
+    `
+  }
 
   return (
     <Card className="relative overflow-hidden">
@@ -210,8 +210,8 @@ export default function InteractiveMap({
         ref={mapRef}
         sx={{
           height: height,
-          width: "100%",
-          position: "relative",
+          width: '100%',
+          position: 'relative',
         }}
       />
 
@@ -246,7 +246,7 @@ export default function InteractiveMap({
             size="small"
             className="absolute top-16 right-4 bg-white hover:bg-gray-50 shadow-md"
             onClick={() =>
-              setMapType(mapType === "roadmap" ? "satellite" : "roadmap")
+              setMapType(mapType === 'roadmap' ? 'satellite' : 'roadmap')
             }
             sx={{ zIndex: 2 }}
           >
@@ -259,7 +259,7 @@ export default function InteractiveMap({
               カテゴリー
             </Typography>
             <Box className="flex flex-wrap gap-1">
-              {["グルメ", "景観", "文化", "歴史", "自然"].map((category) => (
+              {['グルメ', '景観', '文化', '歴史', '自然'].map((category) => (
                 <Chip
                   key={category}
                   label={category}
@@ -272,5 +272,5 @@ export default function InteractiveMap({
         </>
       )}
     </Card>
-  );
+  )
 }

--- a/front/components/layout/interactive-map.tsx
+++ b/front/components/layout/interactive-map.tsx
@@ -1,46 +1,46 @@
-"use client";
+'use client'
 
-import { useEffect, useRef, useState } from "react";
-import { Box, Card, Typography, Chip, Fab } from "@mui/material";
-import { LocationOn, MyLocation, Layers } from "@mui/icons-material";
+import { LocationOn, MyLocation, Layers } from '@mui/icons-material'
+import { Box, Card, Typography, Chip, Fab } from '@mui/material'
+import { useEffect, useRef, useState } from 'react'
 import {
   mockSpotLocations,
   KAMAKURA_CENTER,
   type SpotLocation,
   type MapLocation,
-} from "@/lib/google-maps";
+} from '@/lib/google-maps'
 
 interface InteractiveMapProps {
-  selectedSpot?: SpotLocation | null;
-  onSpotSelect?: (spot: SpotLocation) => void;
-  height?: string;
-  showControls?: boolean;
+  selectedSpot?: SpotLocation | null
+  onSpotSelect?: (spot: SpotLocation) => void
+  height?: string
+  showControls?: boolean
 }
 
 declare global {
   interface Window {
-    google: any;
-    initMap: () => void;
+    google: unknown
+    initMap: () => void
   }
 }
 
 export default function InteractiveMap({
   selectedSpot,
   onSpotSelect,
-  height = "400px",
+  height = '400px',
   showControls = true,
 }: InteractiveMapProps) {
-  const mapRef = useRef<HTMLDivElement>(null);
-  const [map, setMap] = useState<any>(null);
-  const [markers, setMarkers] = useState<any[]>([]);
-  const [userLocation, setUserLocation] = useState<MapLocation | null>(null);
-  const [mapType, setMapType] = useState<"roadmap" | "satellite">("roadmap");
-  const [isLoading, setIsLoading] = useState(true);
+  const mapRef = useRef<HTMLDivElement>(null)
+  const [map, setMap] = useState<unknown>(null)
+  const [markers, setMarkers] = useState<unknown[]>([])
+  const [setUserLocation] = useState<MapLocation | null>(null)
+  const [mapType, setMapType] = useState<'roadmap' | 'satellite'>('roadmap')
+  const [isLoading, setIsLoading] = useState(true)
 
   // Google Maps APIの初期化
   useEffect(() => {
     const initializeMap = () => {
-      if (!mapRef.current || !window.google) return;
+      if (!mapRef.current || !window.google) return
 
       const mapInstance = new window.google.maps.Map(mapRef.current, {
         center: KAMAKURA_CENTER,
@@ -48,18 +48,18 @@ export default function InteractiveMap({
         mapTypeId: mapType,
         styles: [
           {
-            featureType: "poi",
-            elementType: "labels",
-            stylers: [{ visibility: "off" }],
+            featureType: 'poi',
+            elementType: 'labels',
+            stylers: [{ visibility: 'off' }],
           },
         ],
         mapTypeControl: false,
         streetViewControl: false,
         fullscreenControl: false,
-      });
+      })
 
-      setMap(mapInstance);
-      setIsLoading(false);
+      setMap(mapInstance)
+      setIsLoading(false)
 
       // マーカーを追加
       const newMarkers = mockSpotLocations.map((spot) => {
@@ -71,60 +71,60 @@ export default function InteractiveMap({
             url: getCategoryIcon(spot.category),
             scaledSize: new window.google.maps.Size(40, 40),
           },
-        });
+        })
 
         // 情報ウィンドウ
         const infoWindow = new window.google.maps.InfoWindow({
           content: createInfoWindowContent(spot),
-        });
+        })
 
-        marker.addListener("click", () => {
+        marker.addListener('click', () => {
           // 他の情報ウィンドウを閉じる
-          markers.forEach((m) => m.infoWindow?.close());
-          infoWindow.open(mapInstance, marker);
-          onSpotSelect?.(spot);
-        });
+          markers.forEach((m) => m.infoWindow?.close())
+          infoWindow.open(mapInstance, marker)
+          onSpotSelect?.(spot)
+        })
 
-        return { marker, infoWindow, spot };
-      });
+        return { marker, infoWindow, spot }
+      })
 
-      setMarkers(newMarkers);
-    };
+      setMarkers(newMarkers)
+    }
 
     // Google Maps APIが読み込まれているかチェック
     if (window.google && window.google.maps) {
-      initializeMap();
+      initializeMap()
     } else {
       // Google Maps APIを動的に読み込み
-      const script = document.createElement("script");
-      script.src = `https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places&callback=initMap`;
-      script.async = true;
-      script.defer = true;
+      const script = document.createElement('script')
+      script.src = `https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places&callback=initMap`
+      script.async = true
+      script.defer = true
 
-      window.initMap = initializeMap;
-      document.head.appendChild(script);
+      window.initMap = initializeMap
+      document.head.appendChild(script)
 
       return () => {
-        document.head.removeChild(script);
-        delete window.initMap;
-      };
+        document.head.removeChild(script)
+        delete window.initMap
+      }
     }
-  }, [mapType, onSpotSelect]);
+  }, [mapType, onSpotSelect])
 
   // 選択されたスポットにフォーカス
   useEffect(() => {
     if (map && selectedSpot) {
-      map.setCenter({ lat: selectedSpot.lat, lng: selectedSpot.lng });
-      map.setZoom(16);
+      map.setCenter({ lat: selectedSpot.lat, lng: selectedSpot.lng })
+      map.setZoom(16)
 
       // 対応するマーカーの情報ウィンドウを開く
-      const targetMarker = markers.find((m) => m.spot.id === selectedSpot.id);
+      const targetMarker = markers.find((m) => m.spot.id === selectedSpot.id)
       if (targetMarker) {
-        markers.forEach((m) => m.infoWindow?.close());
-        targetMarker.infoWindow.open(map, targetMarker.marker);
+        markers.forEach((m) => m.infoWindow?.close())
+        targetMarker.infoWindow.open(map, targetMarker.marker)
       }
     }
-  }, [selectedSpot, map, markers]);
+  }, [selectedSpot, map, markers])
 
   // 現在地を取得
   const getCurrentLocation = () => {
@@ -134,21 +134,21 @@ export default function InteractiveMap({
           const location = {
             lat: position.coords.latitude,
             lng: position.coords.longitude,
-          };
-          setUserLocation(location);
+          }
+          setUserLocation(location)
 
           if (map) {
-            map.setCenter(location);
-            map.setZoom(15);
+            map.setCenter(location)
+            map.setZoom(15)
 
             // 現在地マーカーを追加
             new window.google.maps.Marker({
               position: location,
               map: map,
-              title: "現在地",
+              title: '現在地',
               icon: {
                 url:
-                  "data:image/svg+xml;charset=UTF-8," +
+                  'data:image/svg+xml;charset=UTF-8,' +
                   encodeURIComponent(`
                   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <circle cx="12" cy="12" r="8" fill="#4285F4" stroke="#ffffff" strokeWidth="2"/>
@@ -157,37 +157,37 @@ export default function InteractiveMap({
                 `),
                 scaledSize: new window.google.maps.Size(24, 24),
               },
-            });
+            })
           }
         },
         (error) => {
-          console.error("位置情報の取得に失敗しました:", error);
-        }
-      );
+          console.error('位置情報の取得に失敗しました:', error)
+        },
+      )
     }
-  };
+  }
 
   // カテゴリー別アイコンを取得
   const getCategoryIcon = (category: string): string => {
     const iconMap: { [key: string]: string } = {
-      グルメ: "#FF6B6B",
-      景観: "#4ECDC4",
-      文化: "#45B7D1",
-      歴史: "#96CEB4",
-      自然: "#FFEAA7",
-    };
+      グルメ: '#FF6B6B',
+      景観: '#4ECDC4',
+      文化: '#45B7D1',
+      歴史: '#96CEB4',
+      自然: '#FFEAA7',
+    }
 
-    const color = iconMap[category] || "#DDA0DD";
+    const color = iconMap[category] || '#DDA0DD'
     return (
-      "data:image/svg+xml;charset=UTF-8," +
+      'data:image/svg+xml;charset=UTF-8,' +
       encodeURIComponent(`
         <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
           <circle cx="20" cy="20" r="18" fill="${color}" stroke="#ffffff" strokeWidth="2"/>
           <circle cx="20" cy="20" r="8" fill="#ffffff"/>
         </svg>
       `)
-    );
-  };
+    )
+  }
 
   // 情報ウィンドウのコンテンツを作成
   const createInfoWindowContent = (spot: SpotLocation): string => {
@@ -201,8 +201,8 @@ export default function InteractiveMap({
           <span style="font-size: 14px; font-weight: bold;">${spot.rating}</span>
         </div>
       </div>
-    `;
-  };
+    `
+  }
 
   return (
     <Card className="relative overflow-hidden">
@@ -210,8 +210,8 @@ export default function InteractiveMap({
         ref={mapRef}
         sx={{
           height: height,
-          width: "100%",
-          position: "relative",
+          width: '100%',
+          position: 'relative',
         }}
       />
 
@@ -246,7 +246,7 @@ export default function InteractiveMap({
             size="small"
             className="absolute top-16 right-4 bg-white hover:bg-gray-50 shadow-md"
             onClick={() =>
-              setMapType(mapType === "roadmap" ? "satellite" : "roadmap")
+              setMapType(mapType === 'roadmap' ? 'satellite' : 'roadmap')
             }
             sx={{ zIndex: 2 }}
           >
@@ -259,7 +259,7 @@ export default function InteractiveMap({
               カテゴリー
             </Typography>
             <Box className="flex flex-wrap gap-1">
-              {["グルメ", "景観", "文化", "歴史", "自然"].map((category) => (
+              {['グルメ', '景観', '文化', '歴史', '自然'].map((category) => (
                 <Chip
                   key={category}
                   label={category}
@@ -272,5 +272,5 @@ export default function InteractiveMap({
         </>
       )}
     </Card>
-  );
+  )
 }

--- a/front/components/layout/interactive-map.tsx
+++ b/front/components/layout/interactive-map.tsx
@@ -1,52 +1,46 @@
-'use client'
+"use client";
 
-import { LocationOn, MyLocation, Layers } from '@mui/icons-material'
-import { Box, Card, Typography, Chip, Fab } from '@mui/material'
-import { useEffect, useRef, useState } from 'react'
+import { LocationOn, MyLocation, Layers } from "@mui/icons-material";
+import { Box, Card, Typography, Chip, Fab } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
 import {
   mockSpotLocations,
   KAMAKURA_CENTER,
   type SpotLocation,
   type MapLocation,
-} from '@/lib/google-maps'
+} from "@/lib/google-maps";
 
 interface InteractiveMapProps {
-  selectedSpot?: SpotLocation | null
-  onSpotSelect?: (spot: SpotLocation) => void
-  height?: string
-  showControls?: boolean
+  selectedSpot?: SpotLocation | null;
+  onSpotSelect?: (spot: SpotLocation) => void;
+  height?: string;
+  showControls?: boolean;
 }
 
 declare global {
   interface Window {
-    google: typeof google
-    initMap?: () => void
+    google: any
+    initMap: () => void;
   }
 }
 
 export default function InteractiveMap({
   selectedSpot,
   onSpotSelect,
-  height = '400px',
+  height = "400px",
   showControls = true,
 }: InteractiveMapProps) {
-  const mapRef = useRef<HTMLDivElement>(null)
-  const [map, setMap] = useState<google.maps.Map | null>(null)
-  const [markers, setMarkers] = useState<
-    {
-      marker: google.maps.Marker
-      infoWindow: google.maps.InfoWindow
-      spot: SpotLocation
-    }[]
-  >([])
-  const [setUserLocation] = useState<MapLocation | null>(null)
-  const [mapType, setMapType] = useState<'roadmap' | 'satellite'>('roadmap')
-  const [isLoading, setIsLoading] = useState(true)
+  const mapRef = useRef<HTMLDivElement>(null);
+  const [map, setMap] = useState<any>(null);
+  const [markers, setMarkers] = useState<any[]>([]);
+  const [setUserLocation] = useState<MapLocation | null>(null);
+  const [mapType, setMapType] = useState<"roadmap" | "satellite">("roadmap");
+  const [isLoading, setIsLoading] = useState(true);
 
   // Google Maps APIの初期化
   useEffect(() => {
     const initializeMap = () => {
-      if (!mapRef.current || !window.google) return
+      if (!mapRef.current || !window.google) return;
 
       const mapInstance = new window.google.maps.Map(mapRef.current, {
         center: KAMAKURA_CENTER,
@@ -54,18 +48,18 @@ export default function InteractiveMap({
         mapTypeId: mapType,
         styles: [
           {
-            featureType: 'poi',
-            elementType: 'labels',
-            stylers: [{ visibility: 'off' }],
+            featureType: "poi",
+            elementType: "labels",
+            stylers: [{ visibility: "off" }],
           },
         ],
         mapTypeControl: false,
         streetViewControl: false,
         fullscreenControl: false,
-      })
+      });
 
-      setMap(mapInstance)
-      setIsLoading(false)
+      setMap(mapInstance);
+      setIsLoading(false);
 
       // マーカーを追加
       const newMarkers = mockSpotLocations.map((spot) => {
@@ -77,60 +71,60 @@ export default function InteractiveMap({
             url: getCategoryIcon(spot.category),
             scaledSize: new window.google.maps.Size(40, 40),
           },
-        })
+        });
 
         // 情報ウィンドウ
         const infoWindow = new window.google.maps.InfoWindow({
           content: createInfoWindowContent(spot),
-        })
+        });
 
-        marker.addListener('click', () => {
+        marker.addListener("click", () => {
           // 他の情報ウィンドウを閉じる
-          markers.forEach((m) => m.infoWindow?.close())
-          infoWindow.open(mapInstance, marker)
-          onSpotSelect?.(spot)
-        })
+          markers.forEach((m) => m.infoWindow?.close());
+          infoWindow.open(mapInstance, marker);
+          onSpotSelect?.(spot);
+        });
 
-        return { marker, infoWindow, spot }
-      })
+        return { marker, infoWindow, spot };
+      });
 
-      setMarkers(newMarkers)
-    }
+      setMarkers(newMarkers);
+    };
 
     // Google Maps APIが読み込まれているかチェック
     if (window.google && window.google.maps) {
-      initializeMap()
+      initializeMap();
     } else {
       // Google Maps APIを動的に読み込み
-      const script = document.createElement('script')
-      script.src = `https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places&callback=initMap`
-      script.async = true
-      script.defer = true
+      const script = document.createElement("script");
+      script.src = `https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places&callback=initMap`;
+      script.async = true;
+      script.defer = true;
 
-      window.initMap = initializeMap
-      document.head.appendChild(script)
+      window.initMap = initializeMap;
+      document.head.appendChild(script);
 
       return () => {
-        document.head.removeChild(script)
-        delete window.initMap
-      }
+        document.head.removeChild(script);
+        delete window.initMap;
+      };
     }
-  }, [mapType, onSpotSelect])
+  }, [mapType, onSpotSelect]);
 
   // 選択されたスポットにフォーカス
   useEffect(() => {
     if (map && selectedSpot) {
-      map.setCenter({ lat: selectedSpot.lat, lng: selectedSpot.lng })
-      map.setZoom(16)
+      map.setCenter({ lat: selectedSpot.lat, lng: selectedSpot.lng });
+      map.setZoom(16);
 
       // 対応するマーカーの情報ウィンドウを開く
-      const targetMarker = markers.find((m) => m.spot.id === selectedSpot.id)
+      const targetMarker = markers.find((m) => m.spot.id === selectedSpot.id);
       if (targetMarker) {
-        markers.forEach((m) => m.infoWindow?.close())
-        targetMarker.infoWindow.open(map, targetMarker.marker)
+        markers.forEach((m) => m.infoWindow?.close());
+        targetMarker.infoWindow.open(map, targetMarker.marker);
       }
     }
-  }, [selectedSpot, map, markers])
+  }, [selectedSpot, map, markers]);
 
   // 現在地を取得
   const getCurrentLocation = () => {
@@ -140,21 +134,21 @@ export default function InteractiveMap({
           const location = {
             lat: position.coords.latitude,
             lng: position.coords.longitude,
-          }
-          setUserLocation(location)
+          };
+          setUserLocation(location);
 
           if (map) {
-            map.setCenter(location)
-            map.setZoom(15)
+            map.setCenter(location);
+            map.setZoom(15);
 
             // 現在地マーカーを追加
             new window.google.maps.Marker({
               position: location,
               map: map,
-              title: '現在地',
+              title: "現在地",
               icon: {
                 url:
-                  'data:image/svg+xml;charset=UTF-8,' +
+                  "data:image/svg+xml;charset=UTF-8," +
                   encodeURIComponent(`
                   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <circle cx="12" cy="12" r="8" fill="#4285F4" stroke="#ffffff" strokeWidth="2"/>
@@ -163,37 +157,37 @@ export default function InteractiveMap({
                 `),
                 scaledSize: new window.google.maps.Size(24, 24),
               },
-            })
+            });
           }
         },
         (error) => {
-          console.error('位置情報の取得に失敗しました:', error)
-        },
-      )
+          console.error("位置情報の取得に失敗しました:", error);
+        }
+      );
     }
-  }
+  };
 
   // カテゴリー別アイコンを取得
   const getCategoryIcon = (category: string): string => {
     const iconMap: { [key: string]: string } = {
-      グルメ: '#FF6B6B',
-      景観: '#4ECDC4',
-      文化: '#45B7D1',
-      歴史: '#96CEB4',
-      自然: '#FFEAA7',
-    }
+      グルメ: "#FF6B6B",
+      景観: "#4ECDC4",
+      文化: "#45B7D1",
+      歴史: "#96CEB4",
+      自然: "#FFEAA7",
+    };
 
-    const color = iconMap[category] || '#DDA0DD'
+    const color = iconMap[category] || "#DDA0DD";
     return (
-      'data:image/svg+xml;charset=UTF-8,' +
+      "data:image/svg+xml;charset=UTF-8," +
       encodeURIComponent(`
         <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
           <circle cx="20" cy="20" r="18" fill="${color}" stroke="#ffffff" strokeWidth="2"/>
           <circle cx="20" cy="20" r="8" fill="#ffffff"/>
         </svg>
       `)
-    )
-  }
+    );
+  };
 
   // 情報ウィンドウのコンテンツを作成
   const createInfoWindowContent = (spot: SpotLocation): string => {
@@ -207,8 +201,8 @@ export default function InteractiveMap({
           <span style="font-size: 14px; font-weight: bold;">${spot.rating}</span>
         </div>
       </div>
-    `
-  }
+    `;
+  };
 
   return (
     <Card className="relative overflow-hidden">
@@ -216,8 +210,8 @@ export default function InteractiveMap({
         ref={mapRef}
         sx={{
           height: height,
-          width: '100%',
-          position: 'relative',
+          width: "100%",
+          position: "relative",
         }}
       />
 
@@ -252,7 +246,7 @@ export default function InteractiveMap({
             size="small"
             className="absolute top-16 right-4 bg-white hover:bg-gray-50 shadow-md"
             onClick={() =>
-              setMapType(mapType === 'roadmap' ? 'satellite' : 'roadmap')
+              setMapType(mapType === "roadmap" ? "satellite" : "roadmap")
             }
             sx={{ zIndex: 2 }}
           >
@@ -265,7 +259,7 @@ export default function InteractiveMap({
               カテゴリー
             </Typography>
             <Box className="flex flex-wrap gap-1">
-              {['グルメ', '景観', '文化', '歴史', '自然'].map((category) => (
+              {["グルメ", "景観", "文化", "歴史", "自然"].map((category) => (
                 <Chip
                   key={category}
                   label={category}
@@ -278,5 +272,5 @@ export default function InteractiveMap({
         </>
       )}
     </Card>
-  )
+  );
 }

--- a/front/components/layout/interactive-map.tsx
+++ b/front/components/layout/interactive-map.tsx
@@ -19,7 +19,7 @@ interface InteractiveMapProps {
 
 declare global {
   interface Window {
-    google: unknown
+    google: typeof google
     initMap: () => void
   }
 }
@@ -31,8 +31,14 @@ export default function InteractiveMap({
   showControls = true,
 }: InteractiveMapProps) {
   const mapRef = useRef<HTMLDivElement>(null)
-  const [map, setMap] = useState<unknown>(null)
-  const [markers, setMarkers] = useState<unknown[]>([])
+  const [map, setMap] = useState<google.maps.Map | null>(null)
+  const [markers, setMarkers] = useState<
+    {
+      marker: google.maps.Marker
+      infoWindow: google.maps.InfoWindow
+      spot: SpotLocation
+    }[]
+  >([])
   const [setUserLocation] = useState<MapLocation | null>(null)
   const [mapType, setMapType] = useState<'roadmap' | 'satellite'>('roadmap')
   const [isLoading, setIsLoading] = useState(true)

--- a/front/lib/google-maps.ts
+++ b/front/lib/google-maps.ts
@@ -1,130 +1,130 @@
 // Google Maps API関連のユーティリティ関数
 
 export interface MapLocation {
-  lat: number;
-  lng: number;
+  lat: number
+  lng: number
 }
 
 export interface SpotLocation extends MapLocation {
-  id: number;
-  name: string;
-  category: string;
-  description: string;
-  rating: number;
-  image: string;
+  id: number
+  name: string
+  category: string
+  description: string
+  rating: number
+  image: string
 }
 
 // 鎌倉の中心座標
 export const KAMAKURA_CENTER: MapLocation = {
   lat: 35.3192,
   lng: 139.5466,
-};
+}
 
 // モックスポットデータ（実際の鎌倉の座標）
 export const mockSpotLocations: SpotLocation[] = [
   {
     id: 1,
-    name: "隠れ茶屋 竹の庵",
-    category: "グルメ",
-    description: "竹林の奥にある秘密の茶屋",
+    name: '隠れ茶屋 竹の庵',
+    category: 'グルメ',
+    description: '竹林の奥にある秘密の茶屋',
     rating: 4.8,
-    image: "/placeholder.svg?height=200&width=300",
+    image: '/placeholder.svg?height=200&width=300',
     lat: 35.3367,
     lng: 139.5468, // 北鎌倉駅周辺
   },
   {
     id: 2,
-    name: "夕日の展望台",
-    category: "景観",
-    description: "絶景の夕日スポット",
+    name: '夕日の展望台',
+    category: '景観',
+    description: '絶景の夕日スポット',
     rating: 4.9,
-    image: "/placeholder.svg?height=200&width=300",
+    image: '/placeholder.svg?height=200&width=300',
     lat: 35.3084,
     lng: 139.5364, // 稲村ヶ崎周辺
   },
   {
     id: 3,
-    name: "古民家ギャラリー",
-    category: "文化",
-    description: "築100年の古民家アートギャラリー",
+    name: '古民家ギャラリー',
+    category: '文化',
+    description: '築100年の古民家アートギャラリー',
     rating: 4.6,
-    image: "/placeholder.svg?height=200&width=300",
+    image: '/placeholder.svg?height=200&width=300',
     lat: 35.3194,
     lng: 139.5503, // 鎌倉駅周辺
   },
   {
     id: 4,
-    name: "秘密の竹林小径",
-    category: "自然",
-    description: "静寂な竹林の散歩道",
+    name: '秘密の竹林小径',
+    category: '自然',
+    description: '静寂な竹林の散歩道',
     rating: 4.7,
-    image: "/placeholder.svg?height=200&width=300",
+    image: '/placeholder.svg?height=200&width=300',
     lat: 35.3373,
     lng: 139.5445, // 報国寺周辺
   },
   {
     id: 5,
-    name: "地元民の愛する蕎麦屋",
-    category: "グルメ",
-    description: "創業50年の手打ち蕎麦",
+    name: '地元民の愛する蕎麦屋',
+    category: 'グルメ',
+    description: '創業50年の手打ち蕎麦',
     rating: 4.8,
-    image: "/placeholder.svg?height=200&width=300",
+    image: '/placeholder.svg?height=200&width=300',
     lat: 35.3156,
     lng: 139.5389, // 長谷駅周辺
   },
   {
     id: 6,
-    name: "隠れ神社の桜",
-    category: "歴史",
-    description: "春限定の美しい桜スポット",
+    name: '隠れ神社の桜',
+    category: '歴史',
+    description: '春限定の美しい桜スポット',
     rating: 4.5,
-    image: "/placeholder.svg?height=200&width=300",
+    image: '/placeholder.svg?height=200&width=300',
     lat: 35.3267,
     lng: 139.5553, // 建長寺周辺
   },
-];
+]
 
 // Google Maps埋め込みURL生成
 export const generateGoogleMapsEmbedUrl = (
   location: MapLocation,
-  zoom = 15
+  zoom = 15,
 ): string => {
-  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "";
-  return `https://www.google.com/maps/embed/v1/view?key=${apiKey}&center=${location.lat},${location.lng}&zoom=${zoom}&maptype=roadmap`;
-};
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || ''
+  return `https://www.google.com/maps/embed/v1/view?key=${apiKey}&center=${location.lat},${location.lng}&zoom=${zoom}&maptype=roadmap`
+}
 
 // Google Maps検索URL生成（スポット名での検索）
 export const generateGoogleMapsSearchUrl = (
   spotName: string,
-  location: MapLocation
+  location: MapLocation,
 ): string => {
-  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "";
-  const query = encodeURIComponent(spotName);
-  return `https://www.google.com/maps/embed/v1/search?key=${apiKey}&q=${query}&center=${location.lat},${location.lng}&zoom=16`;
-};
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || ''
+  const query = encodeURIComponent(spotName)
+  return `https://www.google.com/maps/embed/v1/search?key=${apiKey}&q=${query}&center=${location.lat},${location.lng}&zoom=16`
+}
 
 // 距離計算（ハーバーサイン公式）
 export const calculateDistance = (
   pos1: MapLocation,
-  pos2: MapLocation
+  pos2: MapLocation,
 ): number => {
-  const R = 6371; // 地球の半径（km）
-  const dLat = ((pos2.lat - pos1.lat) * Math.PI) / 180;
-  const dLng = ((pos2.lng - pos1.lng) * Math.PI) / 180;
+  const R = 6371 // 地球の半径（km）
+  const dLat = ((pos2.lat - pos1.lat) * Math.PI) / 180
+  const dLng = ((pos2.lng - pos1.lng) * Math.PI) / 180
   const a =
     Math.sin(dLat / 2) * Math.sin(dLat / 2) +
     Math.cos((pos1.lat * Math.PI) / 180) *
       Math.cos((pos2.lat * Math.PI) / 180) *
       Math.sin(dLng / 2) *
-      Math.sin(dLng / 2);
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-  return R * c;
-};
+      Math.sin(dLng / 2)
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  return R * c
+}
 
 // 現在地からの距離を文字列で返す
 export const formatDistance = (distance: number): string => {
   if (distance < 1) {
-    return `${Math.round(distance * 1000)}m`;
+    return `${Math.round(distance * 1000)}m`
   }
-  return `${distance.toFixed(1)}km`;
-};
+  return `${distance.toFixed(1)}km`
+}

--- a/front/lib/google-maps.ts
+++ b/front/lib/google-maps.ts
@@ -1,0 +1,130 @@
+// Google Maps API関連のユーティリティ関数
+
+export interface MapLocation {
+  lat: number;
+  lng: number;
+}
+
+export interface SpotLocation extends MapLocation {
+  id: number;
+  name: string;
+  category: string;
+  description: string;
+  rating: number;
+  image: string;
+}
+
+// 鎌倉の中心座標
+export const KAMAKURA_CENTER: MapLocation = {
+  lat: 35.3192,
+  lng: 139.5466,
+};
+
+// モックスポットデータ（実際の鎌倉の座標）
+export const mockSpotLocations: SpotLocation[] = [
+  {
+    id: 1,
+    name: "隠れ茶屋 竹の庵",
+    category: "グルメ",
+    description: "竹林の奥にある秘密の茶屋",
+    rating: 4.8,
+    image: "/placeholder.svg?height=200&width=300",
+    lat: 35.3367,
+    lng: 139.5468, // 北鎌倉駅周辺
+  },
+  {
+    id: 2,
+    name: "夕日の展望台",
+    category: "景観",
+    description: "絶景の夕日スポット",
+    rating: 4.9,
+    image: "/placeholder.svg?height=200&width=300",
+    lat: 35.3084,
+    lng: 139.5364, // 稲村ヶ崎周辺
+  },
+  {
+    id: 3,
+    name: "古民家ギャラリー",
+    category: "文化",
+    description: "築100年の古民家アートギャラリー",
+    rating: 4.6,
+    image: "/placeholder.svg?height=200&width=300",
+    lat: 35.3194,
+    lng: 139.5503, // 鎌倉駅周辺
+  },
+  {
+    id: 4,
+    name: "秘密の竹林小径",
+    category: "自然",
+    description: "静寂な竹林の散歩道",
+    rating: 4.7,
+    image: "/placeholder.svg?height=200&width=300",
+    lat: 35.3373,
+    lng: 139.5445, // 報国寺周辺
+  },
+  {
+    id: 5,
+    name: "地元民の愛する蕎麦屋",
+    category: "グルメ",
+    description: "創業50年の手打ち蕎麦",
+    rating: 4.8,
+    image: "/placeholder.svg?height=200&width=300",
+    lat: 35.3156,
+    lng: 139.5389, // 長谷駅周辺
+  },
+  {
+    id: 6,
+    name: "隠れ神社の桜",
+    category: "歴史",
+    description: "春限定の美しい桜スポット",
+    rating: 4.5,
+    image: "/placeholder.svg?height=200&width=300",
+    lat: 35.3267,
+    lng: 139.5553, // 建長寺周辺
+  },
+];
+
+// Google Maps埋め込みURL生成
+export const generateGoogleMapsEmbedUrl = (
+  location: MapLocation,
+  zoom = 15
+): string => {
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "";
+  return `https://www.google.com/maps/embed/v1/view?key=${apiKey}&center=${location.lat},${location.lng}&zoom=${zoom}&maptype=roadmap`;
+};
+
+// Google Maps検索URL生成（スポット名での検索）
+export const generateGoogleMapsSearchUrl = (
+  spotName: string,
+  location: MapLocation
+): string => {
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "";
+  const query = encodeURIComponent(spotName);
+  return `https://www.google.com/maps/embed/v1/search?key=${apiKey}&q=${query}&center=${location.lat},${location.lng}&zoom=16`;
+};
+
+// 距離計算（ハーバーサイン公式）
+export const calculateDistance = (
+  pos1: MapLocation,
+  pos2: MapLocation
+): number => {
+  const R = 6371; // 地球の半径（km）
+  const dLat = ((pos2.lat - pos1.lat) * Math.PI) / 180;
+  const dLng = ((pos2.lng - pos1.lng) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((pos1.lat * Math.PI) / 180) *
+      Math.cos((pos2.lat * Math.PI) / 180) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+};
+
+// 現在地からの距離を文字列で返す
+export const formatDistance = (distance: number): string => {
+  if (distance < 1) {
+    return `${Math.round(distance * 1000)}m`;
+  }
+  return `${distance.toFixed(1)}km`;
+};

--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  eslint: {
+    dirs: ['app', 'components', 'lib'],
+  },
+}
 
-export default nextConfig;
+export default nextConfig

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^18"
       },
       "devDependencies": {
+        "@types/google.maps": "^3.58.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -1156,6 +1157,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",

--- a/front/package.json
+++ b/front/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^18"
   },
   "devDependencies": {
+    "@types/google.maps": "^3.58.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/front/package.json
+++ b/front/package.json
@@ -6,8 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint --dir app",
-    "format": "next lint --fix --dir app"
+    "lint": "next lint",
+    "format": "next lint --fix"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
feat: スポット一覧ページ

## 実装内容
スポット一覧ページ・詳細ページ・検索バーを実装した。
出てくるスポットはモックになっているため、のちほど現実のものにする。

## 実装・変更箇所
- add front/app/spots/[id]/page.tsx
- add front/app/spots/page.tsx
- add front/components/layout/google-maps-iframe.tsx
- add front/components/layout/interactive-map.tsx
- add front/lib/google-maps.ts
